### PR TITLE
use cgo pkg-config

### DIFF
--- a/arm64_decomposer.go
+++ b/arm64_decomposer.go
@@ -1,8 +1,8 @@
 package gapstone
 
-// #cgo LDFLAGS: -lcapstone
+// #cgo pkg-config: capstone
 // #include <stdlib.h>
-// #include <capstone/capstone.h>
+// #include <capstone.h>
 import "C"
 import "unsafe"
 import "reflect"

--- a/arm_decomposer.go
+++ b/arm_decomposer.go
@@ -1,8 +1,8 @@
 package gapstone
 
-// #cgo LDFLAGS: -lcapstone
+// #cgo pkg-config: capstone
 // #include <stdlib.h>
-// #include <capstone/capstone.h>
+// #include <capstone.h>
 import "C"
 import "unsafe"
 import "reflect"

--- a/engine.go
+++ b/engine.go
@@ -9,9 +9,9 @@ try reading the *_test.go files.
 */
 package gapstone
 
-// #cgo LDFLAGS: -lcapstone
+// #cgo pkg-config: capstone
 // #include <stdlib.h>
-// #include <capstone/capstone.h>
+// #include <capstone.h>
 import "C"
 import "unsafe"
 import "reflect"

--- a/mips_decomposer.go
+++ b/mips_decomposer.go
@@ -1,8 +1,8 @@
 package gapstone
 
-// #cgo LDFLAGS: -lcapstone
+// #cgo pkg-config: capstone
 // #include <stdlib.h>
-// #include <capstone/capstone.h>
+// #include <capstone.h>
 import "C"
 import "unsafe"
 import "reflect"

--- a/ppc_decomposer.go
+++ b/ppc_decomposer.go
@@ -1,8 +1,8 @@
 package gapstone
 
-// #cgo LDFLAGS: -lcapstone
+// #cgo pkg-config: capstone
 // #include <stdlib.h>
-// #include <capstone/capstone.h>
+// #include <capstone.h>
 import "C"
 import "unsafe"
 import "reflect"

--- a/x86_decomposer.go
+++ b/x86_decomposer.go
@@ -1,8 +1,8 @@
 package gapstone
 
-// #cgo LDFLAGS: -lcapstone
+// #cgo pkg-config: capstone
 // #include <stdlib.h>
-// #include <capstone/capstone.h>
+// #include <capstone.h>
 import "C"
 import "unsafe"
 import "reflect"


### PR DESCRIPTION
Since capstone 2.0 comes with a pkg-config file, use cgos pkg-config
support to setup CFLAGS/LDFLAGS.
