### PR TITLE
fix 386 build

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -45,7 +45,7 @@ var (
 type Engine struct {
 	handle C.csh
 	arch   int
-	mode   int
+	mode   uint
 }
 
 // Information that exists for every Instruction, regardless of arch.
@@ -121,7 +121,7 @@ func (e Engine) Close() error {
 func (e Engine) Arch() int { return e.arch }
 
 // Accessor for the Engine mode CS_MODE_*
-func (e Engine) Mode() int { return e.mode }
+func (e Engine) Mode() uint { return e.mode }
 
 // Check if a particular arch is supported by this engine.
 // To verify if this engine supports everything, use CS_ARCH_ALL
@@ -211,7 +211,7 @@ func (e Engine) Disasm(input []byte, address, count uint64) ([]Instruction, erro
 }
 
 // Create a new Engine with the specified arch and mode
-func New(arch, mode int) (Engine, error) {
+func New(arch int, mode uint) (Engine, error) {
 	var handle C.csh
 	res := C.cs_open(C.cs_arch(arch), C.cs_mode(mode), &handle)
 	if Errno(res) == ErrOK {

--- a/test_resources.go
+++ b/test_resources.go
@@ -10,7 +10,7 @@ type option struct {
 
 type platform struct {
 	arch    int
-	mode    int
+	mode    uint
 	options []option
 	code    string
 	comment string


### PR DESCRIPTION
Building gapstone on 386 currently fails with:

```
$ go build
# github.com/bnagy/gapstone
./test_resources.go:101: constant 2147483652 overflows int
./test_resources.go:122: constant 2147483648 overflows int
./test_resources.go:129: constant 2147483648 overflows int
./test_resources.go:180: constant 2147483652 overflows int
./test_resources.go:228: constant 2147483648 overflows int
./test_resources.go:228: too many errors
```

The problem is the definition of CS_MODE_BIG_ENDIAN (1 << 31) which doesn't fit
into an signed 32-bit int. This pr changes the type of mode in (New() and
Engine) to uint which fixed the build on 386 but unfortunately also changes the
public API.
