### PR TITLE
Add DisasmIter for improved performance

### DIFF
--- a/bench_iter_test.go
+++ b/bench_iter_test.go
@@ -1,3 +1,5 @@
+// +build go1.7
+
 package gapstone
 
 import (

--- a/bench_iter_test.go
+++ b/bench_iter_test.go
@@ -1,0 +1,80 @@
+package gapstone
+
+import (
+	"bytes"
+	"testing"
+)
+
+func benchmarkBasicX86(scale int, b *testing.B) {
+	engine, err := New(CS_ARCH_X86, CS_MODE_32)
+
+	if err != nil {
+		b.Fatal("Failed to initialize engine: %v", err)
+	}
+	defer engine.Close()
+
+	var testCode bytes.Buffer
+	var x86Code32 = "\x8d\x4c\x32\x08\x01\xd8\x81\xc6\x34" +
+		"\x12\x00\x00\x05\x23\x01\x00\x00\x36\x8b\x84\x91" +
+		"\x23\x01\x00\x00\x41\x8d\x84\x39\x89\x67\x00\x00" +
+		"\x8d\x87\x89\x67\x00\x00\xb4\xc6"
+	for i := 0; i < scale; i++ {
+		testCode.WriteString(x86Code32)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		insns, err := engine.Disasm(
+			testCode.Bytes(), // code buffer
+			0x10000,          // starting address
+			0,                // insns to disassemble, 0 for all
+		)
+
+		if err != nil {
+			b.Fatal("Disassembly error: %v", err)
+		}
+		var count uint = 0
+		for _, insn := range insns {
+			count += insn.Id
+		}
+	}
+}
+func BenchmarkBasicX86Small(b *testing.B)  { benchmarkBasicX86(1, b) }
+func BenchmarkBasicX86Medium(b *testing.B) { benchmarkBasicX86(100, b) }
+func BenchmarkBasicX86Large(b *testing.B)  { benchmarkBasicX86(10000, b) }
+func BenchmarkBasicX86XLarge(b *testing.B) { benchmarkBasicX86(1000000, b) }
+
+func benchmarkIterX86(scale int, b *testing.B) {
+	engine, err := New(CS_ARCH_X86, CS_MODE_32)
+
+	if err != nil {
+		b.Fatal("Failed to initialize engine: %v", err)
+	}
+	defer engine.Close()
+
+	var testCode bytes.Buffer
+	var x86Code32 = "\x8d\x4c\x32\x08\x01\xd8\x81\xc6\x34" +
+		"\x12\x00\x00\x05\x23\x01\x00\x00\x36\x8b\x84\x91" +
+		"\x23\x01\x00\x00\x41\x8d\x84\x39\x89\x67\x00\x00" +
+		"\x8d\x87\x89\x67\x00\x00\xb4\xc6"
+	for i := 0; i < scale; i++ {
+		testCode.WriteString(x86Code32)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		insns := engine.DisasmIter(
+			testCode.Bytes(), // code buffer
+			0x10000,          // starting address
+		)
+
+		var count uint = 0
+		for insn := range insns {
+			count += insn.Id
+		}
+	}
+}
+func BenchmarkIterX86Small(b *testing.B)  { benchmarkIterX86(1, b) }
+func BenchmarkIterX86Medium(b *testing.B) { benchmarkIterX86(100, b) }
+func BenchmarkIterX86Large(b *testing.B)  { benchmarkIterX86(10000, b) }
+func BenchmarkIterX86XLarge(b *testing.B) { benchmarkIterX86(1000000, b) }

--- a/engine.go
+++ b/engine.go
@@ -269,64 +269,6 @@ func (e *Engine) Disasm(input []byte, address, count uint64) ([]Instruction, err
 	return []Instruction{}, e.Errno()
 }
 
-// Disassemble a []byte full of opcodes.
-//   * address - Address of the first instruction in the given code buffer.
-//
-// Underlying C resources are automatically free'd by this function.
-func (e *Engine) DisasmIter(input []byte, address uint64) <-chan Instruction {
-	out := make(chan Instruction, 1)
-	go func() {
-		defer close(out)
-		insn := C.cs_malloc(e.handle)
-		defer C.cs_free(insn, C.size_t(1))
-
-		var bptr *C.uint8_t = (*C.uint8_t)(C.CBytes(input))
-		defer C.free(unsafe.Pointer(bptr))
-
-		ilen := C.size_t(len(input))
-		addr := C.uint64_t(address)
-		// Create a slice, and reflect its header
-		var insns []C.cs_insn
-		h := (*reflect.SliceHeader)(unsafe.Pointer(&insns))
-		// Manually fill in the ptr, len and cap from the raw C data
-		h.Data = uintptr(unsafe.Pointer(insn))
-		h.Len = int(1)
-		h.Cap = int(1)
-
-		for C.cs_disasm_iter(
-			e.handle,
-			&bptr,
-			&ilen,
-			&addr,
-			insn,
-		) {
-
-			switch e.arch {
-			case CS_ARCH_ARM:
-				out <- decomposeArm(insns)[0]
-			case CS_ARCH_ARM64:
-				out <- decomposeArm64(insns)[0]
-			case CS_ARCH_MIPS:
-				out <- decomposeMips(insns)[0]
-			case CS_ARCH_X86:
-				out <- decomposeX86(insns)[0]
-			case CS_ARCH_PPC:
-				out <- decomposePPC(insns)[0]
-			case CS_ARCH_SYSZ:
-				out <- decomposeSysZ(insns)[0]
-			case CS_ARCH_SPARC:
-				out <- decomposeSparc(insns)[0]
-			case CS_ARCH_XCORE:
-				out <- decomposeXcore(insns)[0]
-			default:
-				return
-			}
-		}
-		return
-	}()
-	return out
-}
-
 // user callback function prototype
 type SkipDataCB func(buffer []byte, offset int, userData interface{}) int
 

--- a/engine.go
+++ b/engine.go
@@ -269,6 +269,64 @@ func (e *Engine) Disasm(input []byte, address, count uint64) ([]Instruction, err
 	return []Instruction{}, e.Errno()
 }
 
+// Disassemble a []byte full of opcodes.
+//   * address - Address of the first instruction in the given code buffer.
+//
+// Underlying C resources are automatically free'd by this function.
+func (e *Engine) DisasmIter(input []byte, address uint64) <-chan Instruction {
+	out := make(chan Instruction, 1)
+	go func() {
+		defer close(out)
+		insn := C.cs_malloc(e.handle)
+		defer C.cs_free(insn, C.size_t(1))
+
+		var bptr *C.uint8_t = (*C.uint8_t)(C.CBytes(input))
+		defer C.free(unsafe.Pointer(bptr))
+
+		ilen := C.size_t(len(input))
+		addr := C.uint64_t(address)
+		// Create a slice, and reflect its header
+		var insns []C.cs_insn
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&insns))
+		// Manually fill in the ptr, len and cap from the raw C data
+		h.Data = uintptr(unsafe.Pointer(insn))
+		h.Len = int(1)
+		h.Cap = int(1)
+
+		for C.cs_disasm_iter(
+			e.handle,
+			&bptr,
+			&ilen,
+			&addr,
+			insn,
+		) {
+
+			switch e.arch {
+			case CS_ARCH_ARM:
+				out <- decomposeArm(insns)[0]
+			case CS_ARCH_ARM64:
+				out <- decomposeArm64(insns)[0]
+			case CS_ARCH_MIPS:
+				out <- decomposeMips(insns)[0]
+			case CS_ARCH_X86:
+				out <- decomposeX86(insns)[0]
+			case CS_ARCH_PPC:
+				out <- decomposePPC(insns)[0]
+			case CS_ARCH_SYSZ:
+				out <- decomposeSysZ(insns)[0]
+			case CS_ARCH_SPARC:
+				out <- decomposeSparc(insns)[0]
+			case CS_ARCH_XCORE:
+				out <- decomposeXcore(insns)[0]
+			default:
+				return
+			}
+		}
+		return
+	}()
+	return out
+}
+
 // user callback function prototype
 type SkipDataCB func(buffer []byte, offset int, userData interface{}) int
 

--- a/engine_iter.go
+++ b/engine_iter.go
@@ -1,0 +1,83 @@
+// +build go1.7
+
+/*
+Gapstone is a Go binding for the Capstone disassembly library. For examples,
+try reading the *_test.go files.
+
+	Library Author: Nguyen Anh Quynh
+	Binding Author: Ben Nagy
+	License: BSD style - see LICENSE file for details
+    (c) 2013 COSEINC. All Rights Reserved.
+*/
+
+package gapstone
+
+// #cgo LDFLAGS: -lcapstone
+// #cgo freebsd CFLAGS: -I/usr/local/include
+// #cgo freebsd LDFLAGS: -L/usr/local/lib
+// #include <stdlib.h>
+// #include <capstone/capstone.h>
+import "C"
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// Disassemble a []byte full of opcodes.
+//   * address - Address of the first instruction in the given code buffer.
+//
+// Underlying C resources are automatically free'd by this function.
+func (e *Engine) DisasmIter(input []byte, address uint64) <-chan Instruction {
+	out := make(chan Instruction, 1)
+	go func() {
+		defer close(out)
+		insn := C.cs_malloc(e.handle)
+		defer C.cs_free(insn, C.size_t(1))
+
+		var bptr *C.uint8_t = (*C.uint8_t)(C.CBytes(input))
+		defer C.free(unsafe.Pointer(bptr))
+
+		ilen := C.size_t(len(input))
+		addr := C.uint64_t(address)
+		// Create a slice, and reflect its header
+		var insns []C.cs_insn
+		h := (*reflect.SliceHeader)(unsafe.Pointer(&insns))
+		// Manually fill in the ptr, len and cap from the raw C data
+		h.Data = uintptr(unsafe.Pointer(insn))
+		h.Len = int(1)
+		h.Cap = int(1)
+
+		for C.cs_disasm_iter(
+			e.handle,
+			&bptr,
+			&ilen,
+			&addr,
+			insn,
+		) {
+
+			switch e.arch {
+			case CS_ARCH_ARM:
+				out <- decomposeArm(insns)[0]
+			case CS_ARCH_ARM64:
+				out <- decomposeArm64(insns)[0]
+			case CS_ARCH_MIPS:
+				out <- decomposeMips(insns)[0]
+			case CS_ARCH_X86:
+				out <- decomposeX86(insns)[0]
+			case CS_ARCH_PPC:
+				out <- decomposePPC(insns)[0]
+			case CS_ARCH_SYSZ:
+				out <- decomposeSysZ(insns)[0]
+			case CS_ARCH_SPARC:
+				out <- decomposeSparc(insns)[0]
+			case CS_ARCH_XCORE:
+				out <- decomposeXcore(insns)[0]
+			default:
+				return
+			}
+		}
+		return
+	}()
+	return out
+}


### PR DESCRIPTION
This adds a DisasmIter() to the engine that returns a channel of instructions and leverages cs_disasm_iter.  According to capstone.h "some benchmarks shown that cs_disasm_iter() can be 30% faster on random input."  Benchmark data with new changes below:
```
BenchmarkBasicX86Small-8          200000              8839 ns/op
BenchmarkBasicX86Medium-8           2000            739959 ns/op
BenchmarkBasicX86Large-8               5         277681297 ns/op
BenchmarkBasicX86XLarge-8              1        33275348009 ns/op
BenchmarkIterX86Small-8           100000             18217 ns/op
BenchmarkIterX86Medium-8            1000           1371163 ns/op
BenchmarkIterX86Large-8               10         139074940 ns/op
BenchmarkIterX86XLarge-8               1        13919601258 ns/op
PASS
ok      _/Users/bentay/capstone/gapstone      58.789s
```